### PR TITLE
Remove duplicate code snippet, extract into method.

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jdeprscan/BaseJDeprScanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jdeprscan/BaseJDeprScanMojo.java
@@ -29,13 +29,12 @@ import java.util.Set;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.jdeprscan.consumers.JDeprScanConsumer;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
-import org.codehaus.plexus.util.cli.Commandline;
 import org.codehaus.plexus.util.cli.CommandLineUtils.StringStreamConsumer;
+import org.codehaus.plexus.util.cli.Commandline;
 
 /**
  * Base class for all explicit jdeprscan mojos

--- a/src/main/java/org/apache/maven/plugins/jdeprscan/JDeprScanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jdeprscan/JDeprScanMojo.java
@@ -22,6 +22,7 @@ package org.apache.maven.plugins.jdeprscan;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -59,6 +60,6 @@ public class JDeprScanMojo extends BaseJDeprScanMojo
             classPath.add( Paths.get( elm ) );
         }
 
-        return classPath;
+        return Collections.unmodifiableSet( classPath );
     }
 }

--- a/src/main/java/org/apache/maven/plugins/jdeprscan/TestJDeprScanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jdeprscan/TestJDeprScanMojo.java
@@ -22,6 +22,7 @@ package org.apache.maven.plugins.jdeprscan;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -59,6 +60,6 @@ public class TestJDeprScanMojo extends BaseJDeprScanMojo
             classPath.add( Paths.get( elm ) );
         }
 
-        return classPath;
+        return Collections.unmodifiableSet( classPath );
     }
 }


### PR DESCRIPTION
 - Convert line breaks to unix
 - Removed code duplication, refactored into a method
 - made map field `final`. The convention says "Avoid using final modifier on all fields and arguments", but on collections they enforce a specific coding behaviour (i.e. never replace them).
 - order imports alphabetically (consistently)
 - return unmodifiable collections. Not modifying collections you did not create yourself is considered a "good habit". As this is a new plugin which has not been released yet, let's enforce it.

Hint: sadly github/git shows the whole file as replaced. Consider using your favourite IDE/vim/emacs/etc. for a better diff of `JDeprScanConsumer.java`.

Those are all just nits. Just a preparation for the next feature, which might be scanning of dependencies.