### PR TITLE
[MJDEPRSCAN-11] Require pre-11 build for IT

### DIFF
--- a/src/it/projects/jdeprscan-release7/invoker.properties
+++ b/src/it/projects/jdeprscan-release7/invoker.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-invoker.java.version = !21+
+invoker.java.version = !17+
 invoker.goals = verify

--- a/src/it/projects/jdeprscan-release7/invoker.properties
+++ b/src/it/projects/jdeprscan-release7/invoker.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-invoker.java.version = !17+
+invoker.java.version = !11+
 invoker.goals = verify


### PR DESCRIPTION
per Oracle tool docs "You can use jdeprscan relative to the previous three JDK releases. For example, if you are running JDK 9, then you can check against JDK 8, 7, and 6." so JDK 11+ can't check JDK 1.7 deprecations.