### PR TITLE
Use PATH fallback when JAVA_HOME is not set

### DIFF
--- a/src/main/java/org/apache/maven/plugins/jdeprscan/AbstractJDeprScanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jdeprscan/AbstractJDeprScanMojo.java
@@ -92,6 +92,7 @@ public abstract class AbstractJDeprScanMojo extends AbstractMojo {
     }
 
     private String getJDeprScanExecutable() throws IOException {
+
         Toolchain tc = getToolchain();
 
         String jdeprscanExecutable = null;
@@ -100,7 +101,6 @@ public abstract class AbstractJDeprScanMojo extends AbstractMojo {
         }
 
         String jdepsCommand = "jdeprscan" + (SystemUtils.IS_OS_WINDOWS ? ".exe" : "");
-
         File jdeprscanExe;
 
         if (StringUtils.isNotEmpty(jdeprscanExecutable)) {
@@ -128,11 +128,14 @@ public abstract class AbstractJDeprScanMojo extends AbstractMojo {
         // Try to find jdepsExe from JAVA_HOME environment variable
         // ----------------------------------------------------------------------
         if (!jdeprscanExe.exists() || !jdeprscanExe.isFile()) {
+
             Properties env = CommandLineUtils.getSystemEnvVars();
             String javaHome = env.getProperty("JAVA_HOME");
+
             if (StringUtils.isEmpty(javaHome)) {
-                throw new IOException("The environment variable JAVA_HOME is not correctly set.");
+                return jdepsCommand;
             }
+
             if ((!new File(javaHome).getCanonicalFile().exists())
                     || (new File(javaHome).getCanonicalFile().isFile())) {
                 throw new IOException("The environment variable JAVA_HOME=" + javaHome
@@ -147,7 +150,6 @@ public abstract class AbstractJDeprScanMojo extends AbstractMojo {
             throw new IOException("The jdeps executable '" + jdeprscanExe
                     + "' doesn't exist or is not a file. Verify the JAVA_HOME environment variable.");
         }
-
         return jdeprscanExe.getAbsolutePath();
     }
 


### PR DESCRIPTION
This change updates the jdeprscan executable lookup logic to avoid failing immediately when JAVA_HOME is not set.

Previously, if toolchain lookup did not return a usable path and JAVA_HOME was empty, the plugin threw an exception saying that JAVA_HOME was not correctly set.

With this change, the plugin returns the platform-specific command name (`jdeprscan` / `jdeprscan.exe`) so the operating system can resolve it from PATH.

Verification:
- Built the plugin locally with `mvn clean install`
- Cleared JAVA_HOME in the terminal
- Ran `mvn org.apache.maven.plugins:maven-jdeprscan-plugin:3.0.1-SNAPSHOT:jdeprscan -e`
- Confirmed the old JAVA_HOME failure no longer occurs
- Verified full build passes with `mvn clean install`