### PR TITLE
Force English locale for forked jdeprscan (#76)

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -52,3 +52,34 @@ jobs:
 
       - name: Build with Maven
         run: mvn verify --errors --batch-mode --show-version -Prun-its
+
+  # Regression guard for issue #76: the GitHub runners all resolve to an English
+  # locale, so the default matrix above never exercises the localized jdeprscan
+  # output. Run the ITs once with a non-English default locale (Zulu ships the
+  # jdeprscan_de bundle); JAVA_TOOL_OPTIONS is picked up by every forked JVM,
+  # incl. the jdeprscan tool. With the locale pinning in AbstractJDeprScanMojo
+  # this stays green; without it the release8/9 ITs fail.
+  build-non-english-locale:
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: 'maven'
+
+      - name: Build with Maven (German default locale)
+        env:
+          JAVA_TOOL_OPTIONS: -Duser.language=de -Duser.country=DE
+        run: mvn verify --errors --batch-mode --show-version -Prun-its

--- a/src/main/java/org/apache/maven/plugins/jdeprscan/AbstractJDeprScanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/jdeprscan/AbstractJDeprScanMojo.java
@@ -70,11 +70,28 @@ public abstract class AbstractJDeprScanMojo extends AbstractMojo {
         Commandline cmd = new Commandline();
         cmd.setExecutable(jExecutable);
 
+        addFixedLocaleOptions(cmd);
+
         addJDeprScanOptions(cmd);
 
         executeJDeprScanCommandLine(cmd, getConsumer());
 
         verify();
+    }
+
+    /**
+     * Forces the forked {@code jdeprscan} JVM to a fixed English locale.
+     * <p>
+     * The tool's findings (e.g. {@code "... uses deprecated class ..."}) are
+     * localized by the JDK, but {@link org.apache.maven.plugins.jdeprscan.consumers.JDeprScanConsumer}
+     * parses them with English-only regular expressions. Without pinning the
+     * locale, a non-English default (e.g. German {@code "... verwendet die
+     * veraltete Klasse ..."}) is not recognized, so no deprecation is detected
+     * and {@code failOnWarning} never triggers. See issue #76.
+     */
+    static void addFixedLocaleOptions(Commandline cmd) {
+        cmd.createArg().setValue("-J-Duser.language=en");
+        cmd.createArg().setValue("-J-Duser.country=US");
     }
 
     protected CommandLineUtils.StringStreamConsumer getConsumer() {

--- a/src/test/java/org/apache/maven/plugins/jdeprscan/AbstractJDeprScanMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/jdeprscan/AbstractJDeprScanMojoTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.jdeprscan;
+
+import java.util.Arrays;
+
+import org.codehaus.plexus.util.cli.Commandline;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractJDeprScanMojoTest {
+
+    /**
+     * The forked {@code jdeprscan} JVM must be pinned to an English locale so
+     * that {@link org.apache.maven.plugins.jdeprscan.consumers.JDeprScanConsumer}'s
+     * English-only patterns can parse the tool's (otherwise localized) findings.
+     * See issue #76.
+     */
+    @Test
+    void forcesEnglishLocaleOnForkedJvm() {
+        Commandline cmd = new Commandline();
+        cmd.setExecutable("jdeprscan");
+
+        AbstractJDeprScanMojo.addFixedLocaleOptions(cmd);
+
+        String args = Arrays.toString(cmd.getArguments());
+        assertTrue(args.contains("-J-Duser.language=en"), "should pin language to English, was: " + args);
+        assertTrue(args.contains("-J-Duser.country=US"), "should pin country to US, was: " + args);
+    }
+}


### PR DESCRIPTION
Refs #76.

## Root cause
`jdeprscan`'s findings are localized by the JDK. The plugin forks the tool and parses its stdout with `JDeprScanConsumer`, whose regexes only match the English wording (`^class (\S+) uses deprecated class (\S+)`). On a JVM that resolves to a non-English default locale (e.g. German `... verwendet die veraltete Klasse ...`) nothing matches, so no deprecation is detected, `failOnWarning` never triggers, and the scan silently passes. The `-release8` / `-release9` ITs then fail because the build unexpectedly succeeds (`invoker.buildResult = failure`).

This stays invisible on CI because every GitHub runner (incl. Windows) resolves to `en_US`; it bites contributors on non-English machines (reported on Windows + Zulu JDK, German locale).

## Fix
Pin the forked `jdeprscan` JVM to `en`/`US` via `-J-Duser.language=en -J-Duser.country=US`, so its output is always parseable regardless of host locale or JDK vendor. Verified that this explicit `-J` override wins even against a hostile `JAVA_TOOL_OPTIONS=-Duser.language=de`.

## Tests
- Unit test asserting the forked command line pins the locale.
- A `build-non-english-locale` CI job running the ITs under a German default locale (`JAVA_TOOL_OPTIONS`); the existing matrix only exercises English runners. Verified locally: red without the fix, green with it.

(Supersedes the initial IT-only approach: forcing the locale fixes the plugin itself, so the verify.groovy scripts stay unchanged.)
