### PR TITLE
Pin list-* ITs to the reactor plugin version

### DIFF
--- a/src/it/projects/list-default/invoker.properties
+++ b/src/it/projects/list-default/invoker.properties
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-invoker.goals = org.apache.maven.plugins:maven-jdeprscan-plugin:list
+invoker.goals = jdeprscan:list

--- a/src/it/projects/list-default/pom.xml
+++ b/src/it/projects/list-default/pom.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.jdeprscan.its</groupId>
+  <artifactId>list-default</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <!-- Pin the plugin to the reactor build so the IT exercises the version
+       under test instead of the latest released plugin (default resolution
+       for a version-less goal invocation). -->
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jdeprscan-plugin</artifactId>
+          <version>@project.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/projects/list-forremoval/invoker.properties
+++ b/src/it/projects/list-forremoval/invoker.properties
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-invoker.goals = org.apache.maven.plugins:maven-jdeprscan-plugin:list
+invoker.goals = jdeprscan:list

--- a/src/it/projects/list-forremoval/pom.xml
+++ b/src/it/projects/list-forremoval/pom.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.jdeprscan.its</groupId>
+  <artifactId>list-forremoval</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <!-- Pin the plugin to the reactor build so the IT exercises the version
+       under test instead of the latest released plugin (default resolution
+       for a version-less goal invocation). -->
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jdeprscan-plugin</artifactId>
+          <version>@project.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>


### PR DESCRIPTION
## Problem
The `list-default` and `list-forremoval` ITs invoke the plugin's `list` goal by coordinates without a version:

    invoker.goals = org.apache.maven.plugins:maven-jdeprscan-plugin:list

and the IT projects have no `pom.xml`. Maven runs the goal in `standalone-pom` mode and resolves the *latest released* plugin (currently 3.0.0) rather than the reactor build — so these two ITs never exercise the code under test.

This surfaced in #74 (Maven 4 enablement), where @Bukama and @slawekjaranowski diagnosed the accompanying `list-*` failure: the builds there show `maven-jdeprscan-plugin:3.0.0:list`, and the Maven-4 NPE is a core issue fixed by apache/maven#12336. That analysis stopped at the NPE; this PR addresses the orthogonal fact that the ITs test the released plugin regardless of the Maven version.

## Fix
Add a minimal `pom.xml` to each IT that declares the plugin version as `@project.version@` (interpolated by the invoker, exactly as the scan ITs already rely on) and invoke the goal via the `jdeprscan:list` prefix, so the pinned version is used.

## Verification
`mvn clean verify -P run-its` is green on Maven 3.9.16 and on Maven 4.0.0-SNAPSHOT; the `list-*` build logs now show `jdeprscan:3.0.1-SNAPSHOT:list` (the reactor version) instead of `3.0.0`.
